### PR TITLE
Keep production tenant context for Google and availability

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,6 +23,7 @@ ENV NODE_ENV=production PORT=3000 HOSTNAME=0.0.0.0
 WORKDIR /app
 COPY --from=production-deps --chown=node:node /src/node_modules ./node_modules
 COPY --from=builder --chown=node:node /src/node_modules/@tempocove/postgresql-client ./node_modules/@tempocove/postgresql-client
+COPY --from=builder --chown=node:node /src/node_modules/@tempocove/postgresql-client ./apps/web/node_modules/@tempocove/postgresql-client
 COPY --from=builder --chown=node:node /src/apps/web/.next/standalone ./
 COPY --from=builder --chown=node:node /src/apps/web/.next/static ./apps/web/.next/static
 COPY --from=builder --chown=node:node /src/dist ./dist

--- a/apps/web/src/app/api/availability/route.ts
+++ b/apps/web/src/app/api/availability/route.ts
@@ -1,11 +1,23 @@
 import { requireWorkspaceAccess, requireWorkspaceMutationAccess } from "@/server/auth/session";
+import { runWithDatabaseContext } from "@/server/db-context";
 import { getAvailability, setAvailability } from "@/server/services/availability";
 import { apiError, jsonBody, ok } from "@/server/http";
 import { availabilityInput } from "@/server/validation";
 
+function workspaceContext(access: { workspaceId: string; user: { id: string }; sessionHash?: string; role: string }, action: string) {
+  return { mode: "workspace" as const, workspaceId: access.workspaceId, userId: access.user.id, sessionHash: access.sessionHash, subject: access.role, action };
+}
+
 export async function GET(request: Request) {
-  try { const access = await requireWorkspaceAccess(request); return ok(await getAvailability(access.workspaceId, access.user.id)); } catch (error) { return apiError(error); }
+  try {
+    const access = await requireWorkspaceAccess(request);
+    return runWithDatabaseContext(workspaceContext(access, "workspace_read"), async () => ok(await getAvailability(access.workspaceId, access.user.id)));
+  } catch (error) { return apiError(error); }
 }
 export async function PUT(request: Request) {
-  try { const access = await requireWorkspaceMutationAccess(request); return ok(await setAvailability(access.workspaceId, access.user.id, availabilityInput.parse(await jsonBody(request)))); } catch (error) { return apiError(error); }
+  try {
+    const payload = availabilityInput.parse(await jsonBody(request));
+    const access = await requireWorkspaceMutationAccess(request);
+    return runWithDatabaseContext(workspaceContext(access, "availability_write"), async () => ok(await setAvailability(access.workspaceId, access.user.id, payload)));
+  } catch (error) { return apiError(error); }
 }

--- a/apps/web/src/app/api/event-types/[id]/route.ts
+++ b/apps/web/src/app/api/event-types/[id]/route.ts
@@ -11,5 +11,5 @@ export async function PATCH(request: Request, context: Context) {
   try { const access = await requireWorkspaceMutationAccess(request, "ADMIN"); const { id } = await context.params; return ok(await updateEventType(access.workspaceId, access.user.id, id, updateEventTypeInput.parse(await jsonBody(request)))); } catch (error) { return apiError(error); }
 }
 export async function DELETE(request: Request, context: Context) {
-  try { const access = await requireWorkspaceMutationAccess(request, "ADMIN"); const { id } = await context.params; await deleteEventType(access.workspaceId, id); return ok({ deleted: true as const }); } catch (error) { return apiError(error); }
+  try { const access = await requireWorkspaceMutationAccess(request, "ADMIN"); const { id } = await context.params; await deleteEventType(access.workspaceId, id, access.user.id); return ok({ deleted: true as const }); } catch (error) { return apiError(error); }
 }

--- a/apps/web/src/app/api/integrations/google/callback/route.ts
+++ b/apps/web/src/app/api/integrations/google/callback/route.ts
@@ -9,7 +9,7 @@ export async function GET(request: Request) {
     const session = await getSessionRecord(request); await enforceRateLimit(`google-callback:${session ? `user:${session.userId}` : clientAddress(request)}`, 20, 15 * 60_000);
     const query = new URL(request.url).searchParams; const code = query.get("code"); const state = query.get("state");
     if (!session || !code || code.length > 2048 || !state || !/^[A-Za-z0-9_-]{32,128}$/.test(state)) throw new AppError("INVALID_OAUTH_CALLBACK", "Google authorization could not be verified.", 400);
-    await consumeGoogleAuthorization(session.userId, session.id, state, code);
+    await consumeGoogleAuthorization(session.userId, session.id, state, code, undefined, session.activeWorkspaceId);
     return Response.redirect(`${process.env.NEXT_PUBLIC_APP_URL || "http://localhost:3000"}/integrations?google=connected`);
   } catch (error) { return apiError(error); }
 }

--- a/apps/web/src/app/api/integrations/google/status/route.ts
+++ b/apps/web/src/app/api/integrations/google/status/route.ts
@@ -1,10 +1,21 @@
 import { requireWorkspaceAccess, requireWorkspaceMutationAccess } from "@/server/auth/session";
+import { runWithDatabaseContext } from "@/server/db-context";
 import { apiError, ok } from "@/server/http";
 import { disconnectGoogleCalendar, googleCalendarStatus } from "@/server/services/calendar";
 
+function workspaceReadContext(access: { workspaceId: string; user: { id: string }; sessionHash?: string; role: string }) {
+  return { mode: "workspace" as const, workspaceId: access.workspaceId, userId: access.user.id, sessionHash: access.sessionHash, subject: access.role, action: "workspace_read" };
+}
+
 export async function GET(request: Request) {
-  try { const access = await requireWorkspaceAccess(request); return ok(await googleCalendarStatus(access.user.id, access.workspaceId)); } catch (error) { return apiError(error); }
+  try {
+    const access = await requireWorkspaceAccess(request);
+    return runWithDatabaseContext(workspaceReadContext(access), async () => ok(await googleCalendarStatus(access.user.id, access.workspaceId)));
+  } catch (error) { return apiError(error); }
 }
 export async function DELETE(request: Request) {
-  try { const access = await requireWorkspaceMutationAccess(request, "ADMIN"); return ok(await disconnectGoogleCalendar(access.user.id, undefined, new Date(), access.workspaceId)); } catch (error) { return apiError(error); }
+  try {
+    const access = await requireWorkspaceMutationAccess(request, "ADMIN");
+    return runWithDatabaseContext({ ...workspaceReadContext(access), action: "oauth_write", subject: "ADMIN" }, async () => ok(await disconnectGoogleCalendar(access.user.id, undefined, new Date(), access.workspaceId)));
+  } catch (error) { return apiError(error); }
 }

--- a/apps/web/src/app/api/integrations/status/route.ts
+++ b/apps/web/src/app/api/integrations/status/route.ts
@@ -1,4 +1,5 @@
 import { requireWorkspaceAccess } from "@/server/auth/session";
+import { runWithDatabaseContext } from "@/server/db-context";
 import { apiError, ok } from "@/server/http";
 import { googleCalendarStatus } from "@/server/services/calendar";
 import { stripeTestConfigurationReady } from "@/server/stripe-credentials";
@@ -6,10 +7,17 @@ import { stripeTestConfigurationReady } from "@/server/stripe-credentials";
 export async function GET(request: Request) {
   try {
     const access = await requireWorkspaceAccess(request);
-    return ok({
+    return runWithDatabaseContext({
+      mode: "workspace",
+      workspaceId: access.workspaceId,
+      userId: access.user.id,
+      sessionHash: access.sessionHash,
+      subject: access.role,
+      action: "workspace_read",
+    }, async () => ok({
       google: await googleCalendarStatus(access.user.id, access.workspaceId),
       stripe: { configured: stripeTestConfigurationReady(), mode: "test" as const },
       outboxWorker: { enabled: process.env.OUTBOX_WORKER_ENABLED !== "false", activation: "next-node-instrumentation" as const, productionScheduler: "deferred" as const },
-    });
+    }));
   } catch (error) { return apiError(error); }
 }

--- a/apps/web/src/app/api/workspace/route.ts
+++ b/apps/web/src/app/api/workspace/route.ts
@@ -4,5 +4,11 @@ import { completeWorkspaceOnboarding, getAccountSummary } from "@/server/service
 import { workspaceUpdateInput } from "@/server/validation";
 
 export async function PATCH(request: Request) {
-  try { const access = await requireWorkspaceMutationAccess(request, "ADMIN"); workspaceUpdateInput.parse(await jsonBody(request)); await completeWorkspaceOnboarding(access); return ok(await getAccountSummary({ ...access, workspace: { ...access.workspace, onboardingCompletedAt: new Date() } })); } catch (error) { return apiError(error); }
+  try {
+    const payload = await jsonBody(request);
+    workspaceUpdateInput.parse(payload);
+    const access = await requireWorkspaceMutationAccess(request, "ADMIN");
+    await completeWorkspaceOnboarding(access);
+    return ok(await getAccountSummary({ ...access, workspace: { ...access.workspace, onboardingCompletedAt: new Date() } }));
+  } catch (error) { return apiError(error); }
 }

--- a/apps/web/src/server/auth/session.ts
+++ b/apps/web/src/server/auth/session.ts
@@ -102,13 +102,14 @@ export type WorkspaceAccess = {
   workspace: Workspace;
   workspaceId: string;
   role: WorkspaceRole;
+  sessionHash?: string;
 };
 
 export async function requireWorkspaceAccess(request: Request, minimumRole: WorkspaceRole = "MEMBER"): Promise<WorkspaceAccess> {
   const session = await requireSessionRecord(request);
   const role = session.membership.role as WorkspaceRole;
   if (!(role in roleRank) || roleRank[role] < roleRank[minimumRole]) throw new AppError("FORBIDDEN", "You do not have access to this workspace action.", 403);
-  return { sessionId: session.id, user: session.user, membership: session.membership, workspace: session.workspace, workspaceId: session.activeWorkspaceId, role };
+  return { sessionId: session.id, user: session.user, membership: session.membership, workspace: session.workspace, workspaceId: session.activeWorkspaceId, role, sessionHash: session.tokenHash };
 }
 
 export async function requireWorkspaceMutationAccess(request: Request, minimumRole: WorkspaceRole = "MEMBER") {

--- a/apps/web/src/server/db-context.test.ts
+++ b/apps/web/src/server/db-context.test.ts
@@ -1,0 +1,29 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { currentDatabaseContext, runWithDatabaseContext, runWithWorkspaceRead } from "@/server/db-context";
+
+describe("workspace database context", () => {
+  afterEach(() => { vi.unstubAllEnvs(); });
+
+  it("keeps run() context across awaits in production postgres", async () => {
+    vi.stubEnv("NODE_ENV", "production");
+    vi.stubEnv("DATABASE_PROVIDER", "postgresql");
+    let action = "";
+    await runWithDatabaseContext({ mode: "workspace", workspaceId: "workspace-1", userId: "user-1", action: "workspace_read" }, async () => {
+      await Promise.resolve();
+      action = currentDatabaseContext()?.action || "";
+    });
+    expect(action).toBe("workspace_read");
+    expect(currentDatabaseContext()?.action).toBeUndefined();
+  });
+
+  it("rebinds workspace read when ambient context is missing", async () => {
+    vi.stubEnv("NODE_ENV", "production");
+    vi.stubEnv("DATABASE_PROVIDER", "postgresql");
+    let seen = "";
+    await runWithWorkspaceRead("user-1", "workspace-1", async () => {
+      await Promise.resolve();
+      seen = [currentDatabaseContext()?.mode, currentDatabaseContext()?.workspaceId, currentDatabaseContext()?.action].join(":");
+    });
+    expect(seen).toBe("workspace:workspace-1:workspace_read");
+  });
+});

--- a/apps/web/src/server/db-context.ts
+++ b/apps/web/src/server/db-context.ts
@@ -14,8 +14,27 @@ function field(value?: string) { return value || ""; }
 export function contextSignature(context: DatabaseContext) {
   return createHmac("sha256", contextSecret()).update(["v2",context.mode,field(context.workspaceId),field(context.userId),field(context.sessionHash),field(context.subject),field(context.action)].join("\0")).digest("hex");
 }
+export function productionTenantContextEnabled() {
+  return process.env.DATABASE_PROVIDER === "postgresql" && process.env.NODE_ENV === "production";
+}
 export function enterDatabaseContext(context: DatabaseContext) {
-  if (process.env.DATABASE_PROVIDER === "postgresql" && process.env.NODE_ENV === "production") databaseContext.enterWith(context);
+  if (productionTenantContextEnabled()) databaseContext.enterWith(context);
+}
+export async function runWithDatabaseContext<T>(context: DatabaseContext, operation: () => Promise<T>): Promise<T> {
+  if (!productionTenantContextEnabled()) return operation();
+  return databaseContext.run(context, operation);
+}
+export async function runWithWorkspaceRead<T>(userId: string, workspaceId: string, operation: () => Promise<T>): Promise<T> {
+  const current = currentDatabaseContext();
+  if (current?.mode === "public") return operation();
+  return runWithDatabaseContext({
+    mode: "workspace",
+    workspaceId,
+    userId,
+    sessionHash: current?.sessionHash,
+    subject: current?.subject,
+    action: current?.workspaceId === workspaceId && current.action ? current.action : "workspace_read",
+  }, operation);
 }
 export function enterAuthDatabaseContext(subject: string, userId?: string, workspaceId?: string, action = "auth") { enterDatabaseContext({ mode: "auth", subject: subject.toLowerCase(), userId, workspaceId,action }); }
 export function enterBootstrapDatabaseContext(email: string, userId?: string, workspaceId?: string) { enterDatabaseContext({ mode: "bootstrap", workspaceId, userId, subject: [email.toLowerCase(),userId||"",workspaceId||""].join("|"),action:"register" }); }
@@ -23,9 +42,13 @@ export function enterPublicDatabaseContext(slug: string, workspaceId?: string, s
 export function enterPublicBookingDatabaseContext(eventTypeId: string, workspaceId: string, idempotencyKey: string) { enterDatabaseContext({ mode: "public", workspaceId, subject: `${eventTypeId}|${idempotencyKey}`,action:"booking_create" }); }
 export function enterCapabilityDatabaseContext(subject: string, userId?: string, workspaceId?: string, action = "capability") { enterDatabaseContext({ mode: "capability", subject, userId, workspaceId,action }); }
 export function enterProviderDatabaseContext(subject: string, workspaceId?: string, action = "provider_commit") { enterDatabaseContext({ mode: "provider", subject, workspaceId,action }); }
-export function enterDatabaseAction(action:string){
+export function enterDatabaseAction(action:string, scope?: { workspaceId?: string; userId?: string; sessionHash?: string; subject?: string }){
   const current=databaseContext.getStore();
-  if(current)enterDatabaseContext({mode:current.mode,workspaceId:current.workspaceId,userId:current.userId,sessionHash:current.sessionHash,subject:current.subject,action});
+  if (current) {
+    enterDatabaseContext({ mode: current.mode, workspaceId: scope?.workspaceId || current.workspaceId, userId: scope?.userId || current.userId, sessionHash: scope?.sessionHash ?? current.sessionHash, subject: scope?.subject ?? current.subject, action });
+    return;
+  }
+  if (scope?.workspaceId && scope?.userId) enterDatabaseContext({ mode: "workspace", workspaceId: scope.workspaceId, userId: scope.userId, sessionHash: scope.sessionHash, subject: scope.subject, action });
 }
 export function currentDatabaseContext() { return databaseContext.getStore(); }
 export async function installDatabaseContext(transaction: Record<string, unknown>, context: DatabaseContext) {

--- a/apps/web/src/server/http.ts
+++ b/apps/web/src/server/http.ts
@@ -19,7 +19,13 @@ export function apiError(error: unknown) {
       { status: error.status },
     );
   }
-  console.error("Unhandled API error", { type: error instanceof Error ? error.name : "unknown" });
+  const prismaCode = error && typeof error === "object" && "code" in error && typeof (error as { code: unknown }).code === "string" ? (error as { code: string }).code : "";
+  if (/^P\d{4}$/.test(prismaCode)) {
+    console.error("Unhandled API error", { type: error instanceof Error ? error.name : "unknown", code: prismaCode });
+  } else {
+    const message = error instanceof Error ? error.message : "unknown";
+    console.error("Unhandled API error", { type: error instanceof Error ? error.name : "unknown", code: message.length <= 120 && !/eyJ|[A-Za-z0-9_-]{40,}/.test(message) ? message : error instanceof Error ? error.name : "unknown" });
+  }
   return NextResponse.json({ error: { code: "INTERNAL_ERROR", message: "Something went wrong." } }, { status: 500 });
 }
 

--- a/apps/web/src/server/services/accounts.ts
+++ b/apps/web/src/server/services/accounts.ts
@@ -29,7 +29,7 @@ export async function getAccountSummary(access: WorkspaceAccess): Promise<Accoun
 }
 
 export async function updateProfileImage(access: WorkspaceAccess, imageUrl: string | null) {
-  enterDatabaseAction("account_write");
+  enterDatabaseAction("account_write", { workspaceId: access.workspaceId, userId: access.user.id, sessionHash: access.sessionHash, subject: access.role });
   const canonicalImage = imageUrl === null ? null : await canonicalizeImageDataUrl(imageUrl, "imageUrl");
   const user = await db.user.update({ where: { id: access.user.id }, data: { imageUrl: canonicalImage } });
   return mapUser(user);
@@ -61,7 +61,7 @@ export async function registerAccount(input: RegistrationInput, observeWork: (ph
 }
 
 export async function changeAccountPassword(access: WorkspaceAccess, currentPassword: string, newPassword: string) {
-  enterDatabaseAction("account_write");
+  enterDatabaseAction("account_write", { workspaceId: access.workspaceId, userId: access.user.id, sessionHash: access.sessionHash, subject: access.role });
   if (!await verifyPassword(currentPassword, access.user.passwordHash)) throw new AppError("AUTHENTICATION_FAILED", "The account request could not be completed.", 401);
   const passwordHash = await hashPassword(newPassword); const token = createSessionToken(access.user.id); const payload = readSessionToken(token)!; const now = new Date();
   await db.$transaction(async (tx) => {
@@ -74,7 +74,7 @@ export async function changeAccountPassword(access: WorkspaceAccess, currentPass
 }
 
 export async function completeWorkspaceOnboarding(access: WorkspaceAccess) {
-  enterDatabaseAction("workspace_update");
+  enterDatabaseAction("workspace_update", { workspaceId: access.workspaceId, userId: access.user.id, sessionHash: access.sessionHash, subject: access.role });
   await db.workspace.update({ where: { id: access.workspaceId }, data: { onboardingCompletedAt: new Date() } });
 }
 
@@ -83,7 +83,7 @@ export async function listWorkspaceInvitations(workspaceId: string): Promise<Wor
 }
 
 export async function createWorkspaceInvitation(access: WorkspaceAccess, email: string, role: "ADMIN" | "MEMBER") {
-  enterDatabaseAction("invitation_write");
+  enterDatabaseAction("invitation_write", { workspaceId: access.workspaceId, userId: access.user.id, sessionHash: access.sessionHash, subject: access.role });
   const normalized = email.toLowerCase(); const newId = randomBytes(18).toString("base64url");
   await db.$transaction(async (tx) => {
     const actor = await tx.membership.findFirst({ where: { id: access.membership.id, workspaceId: access.workspaceId, userId: access.user.id, status: "ACTIVE", role: { in: ["OWNER","ADMIN"] } } });
@@ -103,7 +103,7 @@ function invalidInvitation() { return new AppError("INVALID_OR_EXPIRED_TOKEN", "
 export async function acceptWorkspaceInvitation(access: WorkspaceAccess, token: string, now = new Date()) {
   const id = actionTokenId(token); if (!id || !access.user.emailVerifiedAt) throw invalidInvitation();
   enterCapabilityDatabaseContext(id,access.user.id);
-  enterDatabaseAction("invitation_accept");
+  enterDatabaseAction("invitation_accept", { workspaceId: access.workspaceId, userId: access.user.id, sessionHash: access.sessionHash, subject: access.role });
   let acceptedWorkspaceId = "";
   await db.$transaction(async (tx) => {
     const invitation = await tx.workspaceInvitation.findUnique({ where: { id } });
@@ -129,7 +129,7 @@ export async function acceptWorkspaceInvitation(access: WorkspaceAccess, token: 
 }
 
 export async function updateMembershipRole(access: WorkspaceAccess, membershipId: string, role: WorkspaceRole, status: "ACTIVE" | "REMOVED") {
-  enterDatabaseAction("membership_change");
+  enterDatabaseAction("membership_change", { workspaceId: access.workspaceId, userId: access.user.id, sessionHash: access.sessionHash, subject: access.role });
   await db.$transaction(async (tx) => {
     const actor = await tx.membership.findFirst({ where: { id: access.membership.id, workspaceId: access.workspaceId, userId: access.user.id, role: "OWNER", status: "ACTIVE" } });
     if (!actor) throw new AppError("FORBIDDEN", "You do not have access to this workspace action.", 403);

--- a/apps/web/src/server/services/availability.test.ts
+++ b/apps/web/src/server/services/availability.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
-import { generateSlots, mergeBusyIntervals } from "@/server/services/availability";
+import { db } from "@/server/db";
+import { generateSlots, getAvailability, mergeBusyIntervals, setAvailability } from "@/server/services/availability";
 
 const eventType = {
   durationMinutes: 30,
@@ -61,5 +62,21 @@ describe("availability slot generation", () => {
       now: new Date("2026-08-20T00:00:00Z"), outputTimeZone: "UTC",
     });
     expect(slots.map((slot) => slot.start)).toEqual(["2026-08-25T10:00:00.000Z"]);
+  });
+});
+
+describe("availability persistence", () => {
+  it("saves weekly hours and the organizer time zone", async () => {
+    const user = await db.user.create({ data: { email: `avail-${crypto.randomUUID()}@example.com`, name: "Avail", passwordHash: "test", timeZone: "UTC" } });
+    const workspace = await db.workspace.create({ data: { name: "Avail workspace", timeZone: "UTC" } });
+    await db.membership.create({ data: { workspaceId: workspace.id, userId: user.id, role: "OWNER" } });
+    try {
+      await setAvailability(workspace.id, user.id, { timeZone: "America/Chicago", intervals: [{ dayOfWeek: 1, startMinute: 540, endMinute: 600 }], overrides: [] });
+      await expect(getAvailability(workspace.id, user.id)).resolves.toMatchObject({ timeZone: "America/Chicago", intervals: [expect.objectContaining({ dayOfWeek: 1, startMinute: 540, endMinute: 600 })] });
+      expect((await db.user.findUniqueOrThrow({ where: { id: user.id } })).timeZone).toBe("America/Chicago");
+    } finally {
+      await db.workspace.delete({ where: { id: workspace.id } });
+      await db.user.delete({ where: { id: user.id } });
+    }
   });
 });

--- a/apps/web/src/server/services/availability.ts
+++ b/apps/web/src/server/services/availability.ts
@@ -1,7 +1,7 @@
 import { DateTime } from "luxon";
 import type { AvailabilityInterval, AvailabilitySchedule, BookingSlot } from "@/lib/contracts";
 import { db } from "@/server/db";
-import { enterDatabaseAction } from "@/server/db-context";
+import { currentDatabaseContext, enterDatabaseAction, runWithDatabaseContext } from "@/server/db-context";
 
 export type BusyInterval = { start: Date; end: Date };
 export type SlotEventType = {
@@ -121,25 +121,44 @@ export async function getAvailability(
 }
 
 export async function setAvailability(workspaceId: string, userId: string, input: AvailabilitySchedule) {
-  enterDatabaseAction("availability_write");
-  await db.$transaction(async (tx) => {
-    const schedule = await tx.availabilitySchedule.upsert({
-      where: { workspaceId_userId: { workspaceId, userId } }, update: { timeZone: input.timeZone }, create: { workspaceId, userId, timeZone: input.timeZone },
-    });
-    await tx.availabilityInterval.deleteMany({ where: { scheduleId: schedule.id } });
-    if (input.intervals.length) {
-      await tx.availabilityInterval.createMany({ data: input.intervals.map((item) => ({
-        scheduleId: schedule.id, dayOfWeek: item.dayOfWeek, startMinute: item.startMinute, endMinute: item.endMinute,
+  const current = currentDatabaseContext();
+  return runWithDatabaseContext({
+    mode: "workspace",
+    workspaceId,
+    userId,
+    sessionHash: current?.sessionHash,
+    subject: current?.subject,
+    action: "availability_write",
+  }, async () => {
+    enterDatabaseAction("availability_write", { workspaceId, userId, sessionHash: current?.sessionHash, subject: current?.subject });
+    await db.$transaction(async (tx) => {
+      const schedule = await tx.availabilitySchedule.upsert({
+        where: { workspaceId_userId: { workspaceId, userId } }, update: { timeZone: input.timeZone }, create: { workspaceId, userId, timeZone: input.timeZone },
+      });
+      await tx.availabilityInterval.deleteMany({ where: { scheduleId: schedule.id } });
+      if (input.intervals.length) {
+        await tx.availabilityInterval.createMany({ data: input.intervals.map((item) => ({
+          scheduleId: schedule.id, dayOfWeek: item.dayOfWeek, startMinute: item.startMinute, endMinute: item.endMinute,
+        })) });
+      }
+      await tx.availabilityOverride.deleteMany({ where: { workspaceId, userId } });
+      if (input.overrides?.length) await tx.availabilityOverride.createMany({ data: input.overrides.map((item) => ({
+        workspaceId, userId, dateKey: item.dateKey, isAvailable: item.isAvailable,
+        startMinute: item.isAvailable ? item.startMinute : null, endMinute: item.isAvailable ? item.endMinute : null,
       })) });
-    }
-    await tx.availabilityOverride.deleteMany({ where: { workspaceId, userId } });
-    if (input.overrides?.length) await tx.availabilityOverride.createMany({ data: input.overrides.map((item) => ({
-      workspaceId, userId, dateKey: item.dateKey, isAvailable: item.isAvailable,
-      startMinute: item.isAvailable ? item.startMinute : null, endMinute: item.isAvailable ? item.endMinute : null,
-    })) });
-    await tx.user.update({ where: { id: userId }, data: { timeZone: input.timeZone } });
+    });
+    await runWithDatabaseContext({
+      mode: "workspace",
+      workspaceId,
+      userId,
+      sessionHash: currentDatabaseContext()?.sessionHash,
+      subject: currentDatabaseContext()?.subject,
+      action: "account_write",
+    }, async () => {
+      await db.user.update({ where: { id: userId }, data: { timeZone: input.timeZone } });
+    });
+    return getAvailability(workspaceId, userId);
   });
-  return getAvailability(workspaceId, userId);
 }
 
 export function stripIntervalIds(intervals: AvailabilityInterval[]) {

--- a/apps/web/src/server/services/branding.ts
+++ b/apps/web/src/server/services/branding.ts
@@ -10,7 +10,7 @@ export async function getBranding(workspaceId: string): Promise<WorkspaceBrandin
 }
 
 export async function setBranding(workspaceId: string, userId: string, input: WorkspaceBranding) {
-  enterDatabaseAction("branding_write");
+  enterDatabaseAction("branding_write", { workspaceId, userId });
   const canonicalLogo = input.logoUrl && !isRemoteImageUrl(input.logoUrl) ? await canonicalizeImageDataUrl(input.logoUrl, "logoUrl") : input.logoUrl;
   return db.$transaction(async (tx) => {
     const existing = await tx.workspaceBranding.findUnique({ where: { workspaceId }, select: { logoUrl: true } });

--- a/apps/web/src/server/services/calendar.test.ts
+++ b/apps/web/src/server/services/calendar.test.ts
@@ -81,6 +81,13 @@ describe("Google Calendar notification adapter", () => {
     await expect(googleCalendarStatus(user.id, user.workspaceId, async () => ({ scopeHealth: "insufficient", missingScopes: [REQUIRED_GOOGLE_CALENDAR_SCOPES[0]] }))).resolves.toMatchObject({ connected: false, provider: "local", requestedProvider: "google", scopeHealth: "insufficient", missingScopes: [REQUIRED_GOOGLE_CALENDAR_SCOPES[0]] });
     await expect(googleCalendarStatus(user.id, user.workspaceId, async () => ({ scopeHealth: "complete", missingScopes: [] }))).resolves.toMatchObject({ connected: true, provider: "google", scopeHealth: "complete", missingScopes: [] });
   });
+  it("reports encrypted database credentials as connected when live scope health is complete", async () => {
+    process.env.CALENDAR_PROVIDER = "google"; process.env.GOOGLE_CLIENT_ID = "client"; process.env.GOOGLE_CLIENT_SECRET = "secret";
+    process.env.TOKEN_ENCRYPTION_KEY = "00112233445566778899aabbccddeeffffeeddccbbaa99887766554433221100";
+    const user = await calendarTestUser("status-db");
+    await db.oAuthConnection.create({ data: { workspaceId: user.workspaceId, userId: user.id, provider: "google", refreshToken: encryptToken("refresh-secret"), disconnectStatus: "ACTIVE", calendarId: "primary" } });
+    await expect(googleCalendarStatus(user.id, user.workspaceId, async () => ({ scopeHealth: "complete", missingScopes: [] }))).resolves.toMatchObject({ connected: true, provider: "google", credentialSource: "encrypted_database", scopeHealth: "complete", missingScopes: [] });
+  });
   it("uses a deterministic provider id and emails the invitee for creates", () => {
     const booking = { ...bookingFixture(), eventTitleSnapshot: "Accepted title", locationTypeSnapshot: "CUSTOM", locationValueSnapshot: "Accepted room" }; const eventId = providerCalendarEventId(booking.id);
     const request = googleCreateEventRequest("primary", eventId, booking);
@@ -306,7 +313,7 @@ describe("Google Calendar notification adapter", () => {
     const stateUrl = new URL(await createGoogleAuthorization(user.id, authSession.id, user.workspaceId));
     const stateId = stateUrl.searchParams.get("state")!;
     const exchange = vi.spyOn(GoogleCalendarService.prototype, "exchangeAuthorizationCode").mockResolvedValue(verifiedAuthorization());
-    await expect(consumeGoogleAuthorization(user.id, authSession.id, stateId, "authorization-code", { beforeFinalize: async () => { await db.oAuthState.update({ where: { id: stateId }, data: { processingToken: "stale-token", processingExpiresAt: new Date("2099-01-01T00:05:00Z") } }); } })).rejects.toThrow("Google OAuth state is already being processed.");
+    await expect(consumeGoogleAuthorization(user.id, authSession.id, stateId, "authorization-code", { beforeFinalize: async () => { await db.oAuthState.update({ where: { id: stateId }, data: { processingToken: "stale-token", processingExpiresAt: new Date("2099-01-01T00:05:00Z") } }); } })).rejects.toMatchObject({ code: "INVALID_OAUTH_CALLBACK" });
     expect(exchange).toHaveBeenCalledTimes(1);
     exchange.mockRestore();
   });

--- a/apps/web/src/server/services/calendar.ts
+++ b/apps/web/src/server/services/calendar.ts
@@ -4,7 +4,7 @@ import { CodeChallengeMethod } from "google-auth-library";
 import { google } from "googleapis";
 import { DateTime } from "luxon";
 import { db } from "@/server/db";
-import { currentDatabaseContext, enterDatabaseAction } from "@/server/db-context";
+import { currentDatabaseContext, enterDatabaseAction, runWithDatabaseContext, runWithWorkspaceRead } from "@/server/db-context";
 import { decryptToken, encryptToken } from "@/server/crypto/tokens";
 import { AppError } from "@/server/errors";
 import type { BusyInterval } from "@/server/services/availability";
@@ -126,10 +126,13 @@ const prismaCredentialStore: GoogleCredentialStore = {
       const stored = rows[0];
       return stored ? { id: stored.connection_id, workspaceId: stored.workspace_id, userId: stored.credential_user_id, accessToken: decryptToken(stored.access_token), refreshToken: decryptToken(stored.refresh_token), expiresAt: stored.expires_at, calendarId: stored.calendar_id, credentialGeneration: stored.credential_generation, disconnectStatus: stored.disconnect_status } : null;
     }
-    if (!workspaceId || !await liveWorkspaceMember(userId, workspaceId)) throw new Error("GOOGLE_WORKSPACE_AUTHORITY_REQUIRED");
-    const stored = await db.oAuthConnection.findUnique({ where: { workspaceId_provider: { workspaceId, provider: "google" } } });
-    if (stored && !await liveWorkspaceMember(stored.userId, workspaceId, "ADMIN")) throw new Error("GOOGLE_CREDENTIAL_OWNER_NOT_ACTIVE");
-    return stored ? { ...stored, accessToken: decryptToken(stored.accessToken), refreshToken: decryptToken(stored.refreshToken) } : null;
+    if (!workspaceId) throw new Error("GOOGLE_WORKSPACE_AUTHORITY_REQUIRED");
+    return runWithWorkspaceRead(userId, workspaceId, async () => {
+      if (!await liveWorkspaceMember(userId, workspaceId)) throw new Error("GOOGLE_WORKSPACE_AUTHORITY_REQUIRED");
+      const stored = await db.oAuthConnection.findUnique({ where: { workspaceId_provider: { workspaceId, provider: "google" } } });
+      if (stored && !await liveWorkspaceMember(stored.userId, workspaceId, "ADMIN")) throw new Error("GOOGLE_CREDENTIAL_OWNER_NOT_ACTIVE");
+      return stored ? { ...stored, accessToken: decryptToken(stored.accessToken), refreshToken: decryptToken(stored.refreshToken) } : null;
+    });
   },
 };
 
@@ -142,10 +145,20 @@ export async function persistRefreshedGoogleTokens(userId: string, source: { kin
     if (rows[0]?.saved) clearGoogleScopeHealthCache(source.workspaceId);
     return rows[0]?.saved === true;
   }
-  if (!await liveWorkspaceMember(userId, source.workspaceId) || !await liveWorkspaceMember(source.credentialUserId, source.workspaceId, "ADMIN")) return false;
-  const saved = await db.oAuthConnection.updateMany({ where: { id: source.connectionId, workspaceId: source.workspaceId, userId: source.credentialUserId, provider: "google", disconnectStatus: "ACTIVE", credentialGeneration: source.credentialGeneration }, data: { accessToken: tokens.accessToken ? encryptToken(tokens.accessToken) : undefined, refreshToken: tokens.refreshToken ? encryptToken(tokens.refreshToken) : undefined, expiresAt: tokens.expiresAt } });
-  if (saved.count === 1) clearGoogleScopeHealthCache(source.workspaceId);
-  return saved.count === 1;
+  const current = currentDatabaseContext();
+  return runWithDatabaseContext({
+    mode: current?.mode === "public" ? "public" : "workspace",
+    workspaceId: source.workspaceId,
+    userId: source.credentialUserId,
+    sessionHash: current?.sessionHash,
+    subject: current?.subject || "ADMIN",
+    action: "oauth_write",
+  }, async () => {
+    if (!await liveWorkspaceMember(userId, source.workspaceId) || !await liveWorkspaceMember(source.credentialUserId, source.workspaceId, "ADMIN")) return false;
+    const saved = await db.oAuthConnection.updateMany({ where: { id: source.connectionId, workspaceId: source.workspaceId, userId: source.credentialUserId, provider: "google", disconnectStatus: "ACTIVE", credentialGeneration: source.credentialGeneration }, data: { accessToken: tokens.accessToken ? encryptToken(tokens.accessToken) : undefined, refreshToken: tokens.refreshToken ? encryptToken(tokens.refreshToken) : undefined, expiresAt: tokens.expiresAt } });
+    if (saved.count === 1) clearGoogleScopeHealthCache(source.workspaceId);
+    return saved.count === 1;
+  });
 }
 
 export class GoogleCalendarService implements CalendarService {
@@ -172,11 +185,13 @@ export class GoogleCalendarService implements CalendarService {
     const clientSecret = process.env.GOOGLE_CLIENT_SECRET;
     if (!clientId || !clientSecret) throw new Error("Google Calendar credentials are not configured.");
     const auth = new google.auth.OAuth2(clientId, clientSecret, `${process.env.NEXT_PUBLIC_APP_URL || "http://localhost:3000"}/api/integrations/google/callback`);
-    const { tokens } = await auth.getToken({ code, codeVerifier });
+    let tokens;
+    try { ({ tokens } = await auth.getToken({ code, codeVerifier })); }
+    catch { throw new AppError("INVALID_OAUTH_CALLBACK", "Google authorization expired or was already used. Start again from Integrations.", 400); }
     assertRequiredGoogleScopes(tokens.scope);
-    if (!tokens.id_token) throw new Error("Google did not return a verifiable identity token.");
+    if (!tokens.id_token) throw new AppError("INVALID_OAUTH_CALLBACK", "Google did not return a verifiable identity token. Start again from Integrations.", 400);
     const ticket = await auth.verifyIdToken({ idToken: tokens.id_token, audience: clientId }); const identity = ticket.getPayload();
-    if (!identity?.sub || identity.nonce !== nonce) throw new Error("Google identity nonce or subject did not match the authorization request.");
+    if (!identity?.sub || identity.nonce !== nonce) throw new AppError("INVALID_OAUTH_CALLBACK", "Google identity did not match the authorization request. Start again from Integrations.", 400);
     return { accessToken: tokens.access_token, refreshToken: tokens.refresh_token, expiresAt: tokens.expiry_date ? new Date(tokens.expiry_date) : null, providerUserId: identity.sub, scope: tokens.scope! };
   }
 
@@ -186,6 +201,7 @@ export class GoogleCalendarService implements CalendarService {
     if (!clientId || !clientSecret) throw new Error("Google Calendar credentials are not configured.");
     const stored = await this.credentials.get(userId, workspaceId);
     if (stored && stored.disconnectStatus !== "ACTIVE") throw new Error("GOOGLE_CREDENTIAL_NOT_ACTIVE");
+    if (stored?.workspaceId) enterDatabaseAction("oauth_write", { workspaceId: stored.workspaceId, userId: stored.userId, subject: "ADMIN" });
     const source = stored?.refreshToken ? { kind: "database" as const, connectionId: stored.id, workspaceId: stored.workspaceId, credentialUserId: stored.userId, credentialGeneration: stored.credentialGeneration } : { kind: "environment" as const };
     const refreshToken = source.kind === "database" ? stored!.refreshToken : workspaceId && environmentGoogleCredentialAllowed(workspaceId) ? process.env.GOOGLE_REFRESH_TOKEN : undefined;
     if (!refreshToken) throw new Error("Google Calendar refresh token is not configured.");
@@ -343,32 +359,51 @@ export function isProviderNotFound(error: unknown) { return typeof error === "ob
 
 async function credentialWorkspace(userId: string, workspaceId?: string) {
   if (!workspaceId) throw new AppError("WORKSPACE_CONTEXT_REQUIRED", "A workspace-bound calendar operation is required.", 400);
-  if (!await liveWorkspaceMember(userId, workspaceId)) throw new AppError("FORBIDDEN", "You no longer have access to this workspace calendar.", 403);
-  return workspaceId;
+  return runWithWorkspaceRead(userId, workspaceId, async () => {
+    if (!await liveWorkspaceMember(userId, workspaceId)) throw new AppError("FORBIDDEN", "You no longer have access to this workspace calendar.", 403);
+    return workspaceId;
+  });
 }
 
-export async function googleCredentialsReady(userId: string, workspaceId?: string) {
-  if (!process.env.GOOGLE_CLIENT_ID || !process.env.GOOGLE_CLIENT_SECRET) return false;
-  const projected = await publicGoogleReady();
-  if (projected !== null) return projected && Boolean(process.env.TOKEN_ENCRYPTION_KEY);
-  const resolvedWorkspaceId = await credentialWorkspace(userId, workspaceId);
+async function googleCredentialsReadyWithin(userId: string, resolvedWorkspaceId: string) {
   const connection = await db.oAuthConnection.findUnique({ where: { workspaceId_provider: { workspaceId: resolvedWorkspaceId, provider: "google" } }, select: { userId: true, refreshToken: true, disconnectStatus: true } });
   if (connection && !await liveWorkspaceMember(connection.userId, resolvedWorkspaceId, "ADMIN")) return false;
   if (connection?.disconnectStatus !== undefined && connection.disconnectStatus !== "ACTIVE") return false;
   if (connection?.refreshToken) return Boolean(process.env.TOKEN_ENCRYPTION_KEY);
   return environmentGoogleCredentialAllowed(resolvedWorkspaceId);
 }
+export async function googleCredentialsReady(userId: string, workspaceId?: string) {
+  if (!process.env.GOOGLE_CLIENT_ID || !process.env.GOOGLE_CLIENT_SECRET) return false;
+  const projected = await publicGoogleReady();
+  if (projected !== null) return projected && Boolean(process.env.TOKEN_ENCRYPTION_KEY);
+  const resolvedWorkspaceId = await credentialWorkspace(userId, workspaceId);
+  return runWithWorkspaceRead(userId, resolvedWorkspaceId, () => googleCredentialsReadyWithin(userId, resolvedWorkspaceId));
+}
 
 export function clearGoogleScopeHealthCache(workspaceId?: string) { if (workspaceId) googleScopeHealthCache.delete(workspaceId); else googleScopeHealthCache.clear(); }
 export async function getGoogleScopeHealth(userId: string, scopeProbe?: () => Promise<GoogleScopeHealth>, now = Date.now(), workspaceId?: string): Promise<GoogleScopeHealth> {
-  const resolvedWorkspaceId = publicGoogleEventId() ? workspaceId : await credentialWorkspace(userId, workspaceId);
-  if (!resolvedWorkspaceId) throw new AppError("WORKSPACE_CONTEXT_REQUIRED", "A workspace-bound calendar operation is required.", 400);
-  if (!await googleCredentialsReady(userId, resolvedWorkspaceId)) { googleScopeHealthCache.delete(resolvedWorkspaceId); return { scopeHealth: "unavailable", missingScopes: [...REQUIRED_GOOGLE_CALENDAR_SCOPES] }; }
+  if (publicGoogleEventId()) {
+    if (!workspaceId) throw new AppError("WORKSPACE_CONTEXT_REQUIRED", "A workspace-bound calendar operation is required.", 400);
+    return getGoogleScopeHealthWithin(userId, workspaceId, scopeProbe, now);
+  }
+  const resolvedWorkspaceId = await credentialWorkspace(userId, workspaceId);
+  return runWithWorkspaceRead(userId, resolvedWorkspaceId, () => getGoogleScopeHealthWithin(userId, resolvedWorkspaceId, scopeProbe, now));
+}
+async function getGoogleScopeHealthWithin(userId: string, resolvedWorkspaceId: string, scopeProbe: (() => Promise<GoogleScopeHealth>) | undefined, now: number): Promise<GoogleScopeHealth> {
+  if (!await googleCredentialsReady(userId, resolvedWorkspaceId)) {
+    console.error("Google credentials not ready", { hasContext: Boolean(currentDatabaseContext()) });
+    googleScopeHealthCache.delete(resolvedWorkspaceId); return { scopeHealth: "unavailable", missingScopes: [...REQUIRED_GOOGLE_CALENDAR_SCOPES] };
+  }
   if (providerProofMode()) return { scopeHealth: "complete", missingScopes: [] };
   const cached = googleScopeHealthCache.get(resolvedWorkspaceId); if (cached && cached.expiresAt > now) return cached.value;
   let value: GoogleScopeHealth;
   try { value = scopeProbe ? await scopeProbe() : await new GoogleCalendarService().scopeHealth(userId, resolvedWorkspaceId); }
-  catch { value = { scopeHealth: "unavailable", missingScopes: [] }; }
+  catch (error) {
+    const raw = error instanceof Error ? error.message : "unknown";
+    const code = raw.length <= 80 && !/eyJ|ya29\.|1\/|aesgcm/.test(raw) ? raw : error instanceof Error ? error.name : "unknown";
+    console.error("Google scope health unavailable", { code });
+    value = { scopeHealth: "unavailable", missingScopes: [] };
+  }
   googleScopeHealthCache.set(resolvedWorkspaceId, { value, expiresAt: now + GOOGLE_SCOPE_HEALTH_TTL_MS }); return value;
 }
 
@@ -426,21 +461,24 @@ export async function googleCalendarStatus(
   const workspaceId = typeof workspaceIdOrLoader === "string" ? workspaceIdOrLoader : undefined;
   const scopeHealthLoader = typeof workspaceIdOrLoader === "function" ? workspaceIdOrLoader : suppliedScopeHealthLoader;
   const resolvedWorkspaceId = await credentialWorkspace(userId, workspaceId);
-  const connection = await db.oAuthConnection.findUnique({ where: { workspaceId_provider: { workspaceId: resolvedWorkspaceId, provider: "google" } } });
-  const credentialsReady = await googleCredentialsReady(userId, resolvedWorkspaceId);
-  const scope = credentialsReady ? await (scopeHealthLoader ? scopeHealthLoader(userId) : getGoogleScopeHealth(userId, undefined, Date.now(), resolvedWorkspaceId)) : { scopeHealth: "unavailable" as const, missingScopes: [...REQUIRED_GOOGLE_CALENDAR_SCOPES] };
-  const ready = process.env.CALENDAR_PROVIDER === "google" && credentialsReady && scope.scopeHealth === "complete";
-  return {
-    configured: Boolean(process.env.GOOGLE_CLIENT_ID && process.env.GOOGLE_CLIENT_SECRET),
-    connected: ready,
-    credentialSource: connection?.refreshToken ? "encrypted_database" as const : environmentGoogleCredentialAllowed(resolvedWorkspaceId) ? "environment" as const : "none" as const,
-    disconnectSupported: Boolean(connection?.refreshToken),
-    disconnectPending: Boolean(connection && connection.disconnectStatus !== "ACTIVE"),
-    provider: ready ? "google" : "local",
-    requestedProvider: process.env.CALENDAR_PROVIDER === "google" ? "google" as const : "local" as const,
-    calendarId: connection?.calendarId || process.env.GOOGLE_CALENDAR_ID || "primary",
-    ...scope,
-  };
+  return runWithWorkspaceRead(userId, resolvedWorkspaceId, async () => {
+    const connection = await db.oAuthConnection.findUnique({ where: { workspaceId_provider: { workspaceId: resolvedWorkspaceId, provider: "google" } } });
+    const credentialsReady = await googleCredentialsReady(userId, resolvedWorkspaceId);
+    if (!credentialsReady) console.error("Google credentials not ready", { hasContext: Boolean(currentDatabaseContext()), hasConnection: Boolean(connection?.refreshToken) });
+    const scope = credentialsReady ? await (scopeHealthLoader ? scopeHealthLoader(userId) : getGoogleScopeHealth(userId, undefined, Date.now(), resolvedWorkspaceId)) : { scopeHealth: "unavailable" as const, missingScopes: [...REQUIRED_GOOGLE_CALENDAR_SCOPES] };
+    const ready = process.env.CALENDAR_PROVIDER === "google" && credentialsReady && scope.scopeHealth === "complete";
+    return {
+      configured: Boolean(process.env.GOOGLE_CLIENT_ID && process.env.GOOGLE_CLIENT_SECRET),
+      connected: ready,
+      credentialSource: connection?.refreshToken ? "encrypted_database" as const : environmentGoogleCredentialAllowed(resolvedWorkspaceId) ? "environment" as const : "none" as const,
+      disconnectSupported: Boolean(connection?.refreshToken),
+      disconnectPending: Boolean(connection && connection.disconnectStatus !== "ACTIVE"),
+      provider: ready ? "google" : "local",
+      requestedProvider: process.env.CALENDAR_PROVIDER === "google" ? "google" as const : "local" as const,
+      calendarId: connection?.calendarId || process.env.GOOGLE_CALENDAR_ID || "primary",
+      ...scope,
+    };
+  });
 }
 
 type VerifiedGoogleAuthorization = { accessToken?: string | null; refreshToken?: string | null; expiresAt?: Date | null; providerUserId: string; scope: string };
@@ -465,9 +503,9 @@ async function persistVerifiedGoogleAuthorizationWithinTransaction(tx: Prisma.Tr
 }
 
 export async function persistVerifiedGoogleAuthorization(userId: string, expectedConnectionId: string | null, expectedConnectionGeneration: number | null, tokens: VerifiedGoogleAuthorization, workspaceId?: string) {
-  enterDatabaseAction("oauth_write");
   assertRequiredGoogleScopes(tokens.scope);
   const resolvedWorkspaceId = await credentialWorkspace(userId, workspaceId);
+  enterDatabaseAction("oauth_write", { workspaceId: resolvedWorkspaceId, userId, subject: "ADMIN" });
   await db.$transaction(async (tx) => { await persistVerifiedGoogleAuthorizationWithinTransaction(tx, userId, expectedConnectionId, expectedConnectionGeneration, tokens, resolvedWorkspaceId); });
   clearGoogleScopeHealthCache(resolvedWorkspaceId);
 }
@@ -476,8 +514,8 @@ export async function disconnectGoogleCalendar(userId: string, revoke: (token: s
   if (!process.env.GOOGLE_CLIENT_ID || !process.env.GOOGLE_CLIENT_SECRET) throw new Error("Google OAuth client is not configured.");
   await new google.auth.OAuth2(process.env.GOOGLE_CLIENT_ID, process.env.GOOGLE_CLIENT_SECRET).revokeToken(token);
 }, now = new Date(), workspaceId?: string) {
-  enterDatabaseAction("oauth_write");
   const resolvedWorkspaceId = await credentialWorkspace(userId, workspaceId);
+  enterDatabaseAction("oauth_write", { workspaceId: resolvedWorkspaceId, userId, subject: "ADMIN" });
   if (!await liveWorkspaceMember(userId, resolvedWorkspaceId, "ADMIN")) throw new AppError("FORBIDDEN", "Administrator access is required to disconnect Google Calendar.", 403);
   const claimed = await db.$transaction(async (tx) => {
     const administrator = await tx.membership.findFirst({ where: { workspaceId: resolvedWorkspaceId, userId, status: "ACTIVE", role: { in: ["OWNER", "ADMIN"] } }, select: { id: true } });
@@ -527,7 +565,7 @@ export async function retryPendingGoogleDisconnects(now = new Date(), revoke?: (
 }
 
 export async function createGoogleAuthorization(userId: string, authSessionId: string, workspaceId?: string) {
-  enterDatabaseAction("oauth_write");
+  enterDatabaseAction("oauth_write", { workspaceId, userId, subject: "ADMIN" });
   const state = randomBytes(32).toString("base64url");
   const codeVerifier = randomBytes(48).toString("base64url");
   const codeChallenge = createHash("sha256").update(codeVerifier).digest("base64url");
@@ -544,15 +582,16 @@ export async function createGoogleAuthorization(userId: string, authSessionId: s
   return new GoogleCalendarService().authorizationUrl(state, codeChallenge, nonce);
 }
 
-export async function consumeGoogleAuthorization(userId: string, authSessionId: string, state: string, code: string, finalizeHooks?: { beforeFinalize?: () => Promise<void>; afterPersist?: () => Promise<void> }) {
-  enterDatabaseAction("oauth_write");
+export async function consumeGoogleAuthorization(userId: string, authSessionId: string, state: string, code: string, finalizeHooks?: { beforeFinalize?: () => Promise<void>; afterPersist?: () => Promise<void> }, workspaceId?: string) {
+  enterDatabaseAction("oauth_write", { workspaceId, userId, subject: "ADMIN" });
   const now = new Date(); const processingToken = randomBytes(18).toString("base64url");
   const activeSession = await db.authSession.findFirst({ where: { id: authSessionId, userId, revokedAt: null, membership: { status: "ACTIVE", role: { in: ["OWNER", "ADMIN"] } } } });
-  if (!activeSession) throw new Error("Google OAuth session is no longer active.");
+  if (!activeSession) throw new AppError("INVALID_OAUTH_CALLBACK", "Sign in again, then reconnect Google Calendar from Integrations.", 401);
+  enterDatabaseAction("oauth_write", { workspaceId: workspaceId || activeSession.activeWorkspaceId, userId, subject: "ADMIN" });
   const record = await db.oAuthState.findFirst({ where: { id: state, workspaceId: activeSession.activeWorkspaceId, userId, authSessionId, consumedAt: null, expiresAt: { gt: now }, OR: [{ processingToken: null }, { processingExpiresAt: { lte: now } }] } });
-  if (!record) throw new Error("Google OAuth state is invalid, expired, or already used.");
+  if (!record) throw new AppError("INVALID_OAUTH_CALLBACK", "This Google authorization is invalid or already used. Start again from Integrations.", 400);
   const claimed = await db.oAuthState.updateMany({ where: { id: state, workspaceId: record.workspaceId, userId, authSessionId, consumedAt: null, OR: [{ processingToken: null }, { processingExpiresAt: { lte: now } }] }, data: { processingToken, processingExpiresAt: new Date(now.getTime() + 60_000) } });
-  if (claimed.count !== 1) throw new Error("Google OAuth state is already being processed.");
+  if (claimed.count !== 1) throw new AppError("INVALID_OAUTH_CALLBACK", "This Google authorization is already being processed. Start again from Integrations.", 409);
   const heartbeat = setInterval(() => { void db.oAuthState.updateMany({ where: { id: state, workspaceId: record.workspaceId, authSessionId, processingToken, consumedAt: null, expiresAt: { gt: new Date() } }, data: { processingExpiresAt: new Date(Date.now() + 60_000) } }).catch(() => undefined); }, 20_000);
   heartbeat.unref();
   try {
@@ -562,11 +601,11 @@ export async function consumeGoogleAuthorization(userId: string, authSessionId: 
       const liveSession = await tx.authSession.findFirst({ where: { id: authSessionId, userId, activeWorkspaceId: record.workspaceId, revokedAt: null, expiresAt: { gt: new Date() }, membership: { status: "ACTIVE", role: { in: ["OWNER", "ADMIN"] }, workspaceId: record.workspaceId, userId } } });
       if (!liveSession) throw new AppError("GOOGLE_CREDENTIAL_FENCE_LOST", "The active workspace changed. Start again.", 409);
       const liveState = await tx.oAuthState.findFirst({ where: { id: state, workspaceId: record.workspaceId, userId, authSessionId, processingToken, consumedAt: null, expiresAt: { gt: new Date() }, processingExpiresAt: { gt: new Date() } } });
-      if (!liveState) throw new Error("Google OAuth state is already being processed.");
+      if (!liveState) throw new AppError("INVALID_OAUTH_CALLBACK", "This Google authorization is already being processed. Start again from Integrations.", 409);
       await persistVerifiedGoogleAuthorizationWithinTransaction(tx, userId, record.expectedConnectionId, record.expectedConnectionGeneration, verified, record.workspaceId);
       if (finalizeHooks?.afterPersist) await finalizeHooks.afterPersist();
       const consumed = await tx.oAuthState.updateMany({ where: { id: state, workspaceId: record.workspaceId, authSessionId, processingToken, consumedAt: null, processingExpiresAt: { gt: new Date() } }, data: { consumedAt: new Date(), codeVerifier: "", nonce: "", processingToken: null, processingExpiresAt: null } });
-      if (consumed.count !== 1) throw new Error("Google OAuth state changed during completion.");
+      if (consumed.count !== 1) throw new AppError("INVALID_OAUTH_CALLBACK", "Google authorization changed during completion. Start again from Integrations.", 409);
     });
     clearGoogleScopeHealthCache(record.workspaceId);
   } catch (error) {

--- a/apps/web/src/server/services/event-types.ts
+++ b/apps/web/src/server/services/event-types.ts
@@ -51,7 +51,7 @@ async function assertLocationReady(workspaceId: string, ownerId: string, locatio
 }
 
 export async function createEventType(workspaceId: string, ownerId: string, input: CreateEventTypeInput) {
-  enterDatabaseAction("event_write");
+  enterDatabaseAction("event_write", { workspaceId, userId: ownerId });
   if (await db.eventType.findUnique({ where: { slug: input.slug } })) throw conflict("That booking link is already in use.");
   const durations = normalizedDurations(input).map((item) => ({
     label: item.label, durationMinutes: item.durationMinutes, isDefault: item.isDefault,
@@ -70,7 +70,7 @@ export async function createEventType(workspaceId: string, ownerId: string, inpu
 }
 
 export async function updateEventType(workspaceId: string, _actingUserId: string, id: string, input: UpdateEventTypeInput, readiness: CalendarReadiness = googleCalendarReady) {
-  enterDatabaseAction("event_write");
+  enterDatabaseAction("event_write", { workspaceId, userId: _actingUserId });
   const current = await db.eventType.findFirst({ where: { id, workspaceId }, include: includeOptions });
   if (!current) throw notFound("Event type");
   if (input.slug && input.slug !== current.slug && await db.eventType.findUnique({ where: { slug: input.slug } })) throw conflict("That booking link is already in use.");
@@ -106,8 +106,8 @@ export async function updateEventType(workspaceId: string, _actingUserId: string
   }));
 }
 
-export async function deleteEventType(workspaceId: string, id: string) {
-  enterDatabaseAction("event_write");
+export async function deleteEventType(workspaceId: string, id: string, userId?: string) {
+  enterDatabaseAction("event_write", { workspaceId, userId });
   const current = await db.eventType.findFirst({ where: { id, workspaceId } });
   if (!current) throw notFound("Event type");
   if (await db.booking.count({ where: { eventTypeId: id } })) await db.eventType.update({ where: { id }, data: { isActive: false } });


### PR DESCRIPTION
## Summary
Production Postgres RLS hid workspace rows after Next.js dropped AsyncLocalStorage across `await`. That made a live Google Calendar connection look unavailable and caused availability saves to fail when updating the organizer timezone.

- Rebind signed tenant context with `runWithDatabaseContext` / reconstructed `enterDatabaseAction` scope on Google status, OAuth token persist, availability, onboarding, and related writes.
- Persist Google token refreshes under `oauth_write`, and update user timezone under `account_write` after the availability schedule write.
- Copy the Prisma query engine into the standalone web path so production signup/readiness can load.
- Log Prisma `P####` codes on unhandled API errors without leaking tokens.

Verified on book.XXX.xyz: Integrations reports Google connected with complete calendar access, and `PUT /api/availability` returns 200.

## Test plan
- [ ] Sign in on a production-path Postgres deploy and confirm Integrations shows Google **Connected** / full calendar access without reconnecting.
- [ ] Save weekly hours on `/availability` and confirm **Availability saved**.
- [ ] Complete onboarding if a new workspace is created.
- [ ] `vitest run apps/web/src/server/db-context.test.ts apps/web/src/server/services/availability.test.ts apps/web/src/server/services/calendar.test.ts`